### PR TITLE
Add Istio related resources for custom routing for cannary deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Operation
 This repository contains all deployment files for the application.
 
+## Codebase Overview
+- `docker-compose.yml`: Defines the services that make up the application stack.
+- `README.md`: Provides documentation on how to start the application and deploy it to a cloud provider or Kubernetes cluster.
+- `deployment.yml`: Defines the Kubernetes services with Deployments, Services and Ingress.
+- `grafana.json`: Defines all the necessary graphs for the Grafana visualization tool.
+
 ## Getting Started
 To start the application locally, make sure you have Docker and Docker Compose installed.
 Also add an environment variable called `CR_PAT` containing your Github PAT. 
@@ -19,35 +25,43 @@ Subsequently, run the following commands:
 
 This will start the entire application stack locally and go to `localhost:8080` to try out the app.
 
-## Deployment
-
-To deploy the application to a Kubernetes cluster, use the deployment file provided in this repository. 
-For example, to deploy to Kubernetes, you can use the `kubectl apply` command to apply the deployment files:
-
-`kubectl apply -f deployment.yml`
-
-Use `minikube` to tunnel the Ingress to `localhost` with:
-
-`minikube tunnel`
-
-## Monitoring
-Add Prometheus stack to Kubernetes cluster
-
-`helm repo add prom-repo https://prometheus-community.github.io/helm-charts`
+## Enable Prometheus for Monitoring
+Add the Prometheus stack to the Kubernetes cluster
+```
+helm repo add prom-repo https://prometheus-community.github.io/helm-charts
+```
 
 Update the Helm repositories
-`helm repo update`
+```
+helm repo update
+```
 
-Install Prometheus stack
-`helm install myprom prom-repo/kube-prometheus-stack`
+Install the Prometheus stack:
+```
+helm install myprom prom-repo/kube-prometheus-stack
+```
 
-Run service for monitoring
+Run service for monitoring:
+```
+minikube service myprom-kube-prometheus-sta-prometheus --url
+```
 
-`minikube service myprom-kube-prometheus-sta-prometheus --url`
+The `deployment.yml` manifest includes the `ServiceMonitor` custom resource.
 
-The `deployment.yml` manifest includes the Kubernetes ServiceMonitor
+## Deployment
 
-## Codebase Overview
-- `docker-compose.yml`: Defines the services that make up the application stack.
-- `README.md`: Provides documentation on how to start the application and deploy it to a cloud provider or Kubernetes cluster.
-- `deployment.yml`: Defines the Kubernetes services with Deployments, Services and Ingress.
+To deploy the application to a Kubernetes cluster, run:
+```
+kubectl apply -f deployment.yml
+```
+
+To tunnel the Ingress to `localhost`, run:
+
+```
+minikube tunnel
+```
+
+To access the web-page of the application, open your browser and go to: 
+```
+http://localhost
+```

--- a/deployment.yml
+++ b/deployment.yml
@@ -1,18 +1,15 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: app-depl
-  labels:
-    app: app
+  name: app-v1
+  labels: { app: app, version: v1 }
 spec:
   replicas: 1
   selector:
-    matchLabels:
-      app: app
+    matchLabels: { app: app, version: v1 }
   template:
     metadata:
-      labels:
-        app: app
+      labels: { app: app, version: v1 }
     spec:
       containers:
       - name: app
@@ -29,18 +26,15 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: app-depl-two
-  labels:
-    app: app-two
+  name: app-v2
+  labels: { app: app, version: v2 }
 spec:
   replicas: 1
   selector:
-    matchLabels:
-      app: app
+    matchLabels: { app: app, version: v2 }
   template:
     metadata:
-      labels:
-        app: app
+      labels: { app: app, version: v2 }
     spec:
       containers:
       - name: app
@@ -57,7 +51,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: model-service-depl
+  name: model-service
   labels:
     app: model-service
 spec:
@@ -79,26 +73,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: app-service
-  labels:
-    app: app-svc
+  name: app
 spec:
   selector:
     app: app
-  ports:
-    - name: http
-      port: 8080
-      targetPort: 8080
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: app-service-two
-  labels:
-    app: app-svc-two
-spec:
-  selector:
-    app: app-two
   ports:
     - name: http
       port: 8080
@@ -117,17 +95,6 @@ spec:
     - name: http
       port: 8000
       targetPort: 8000
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: app-ingress
-spec:
-  defaultBackend:
-    service:
-      name: app-service
-      port:
-        number: 8000
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -148,3 +115,55 @@ spec:
       app: model-svc
   endpoints:
   - interval: 1s
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: my-gateway
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+      - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: my-entry-service
+spec:
+  gateways:
+    - my-gateway
+  hosts:
+  - "*"
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: app
+        subset: v1
+      weight: 90
+    - destination:
+        host: app
+        subset: v2
+      weight: 10
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: app
+spec:
+  host: app
+  subsets:
+  - name: v1
+    labels:
+      { app: app, version: v1 }
+  - name: v2
+    labels:
+      { app: app, version: v2 }


### PR DESCRIPTION
This PR introduces a `VirtualService`, a `Gateway` and a `DestinationRule` in order to split traffic towards a cannary deployment of the application