### PR TITLE
istio: Match `queryParams` to forward requests to correct Pods

### DIFF
--- a/deployment.yml
+++ b/deployment.yml
@@ -144,6 +144,22 @@ spec:
   - "*"
   http:
   - match:
+    - queryParams:
+        version:
+          exact: "2.0.1"
+    route:
+    - destination:
+        host: app
+        subset: v2
+  - match:
+    - queryParams:
+        version:
+          exact: "0.1.1"
+    route:
+    - destination:
+        host: app
+        subset: v1
+  - match:
     - uri:
         prefix: /
     route:


### PR DESCRIPTION
Extend our `VirtualService` to forward incoming requests to the correct version of the app based on the `version` query parameter in the URL.